### PR TITLE
Add Support for Volume Normalization + Fix Night Mode bug

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -532,6 +532,8 @@ namespace Gelatinarm
                 return new UserDataService(logger, apiClient, userProfileService);
             });
 
+            services.AddSingleton<IVolumeNormalizationService, VolumeNormalizationService>();
+
             services.AddSingleton<IMediaOptimizationService>(provider =>
             {
                 var logger = provider.GetRequiredService<ILogger<MediaOptimizationService>>();
@@ -540,8 +542,9 @@ namespace Gelatinarm
                 var memoryMonitor = provider.GetRequiredService<IMemoryMonitor>();
                 var networkMonitor = provider.GetRequiredService<INetworkMonitor>();
                 var httpClientFactory = provider.GetRequiredService<IHttpClientFactory>();
+                var volumeNormalizationService = provider.GetRequiredService<IVolumeNormalizationService>();
                 return new MediaOptimizationService(logger, httpClientFactory, preferencesService, deviceService, memoryMonitor,
-                    networkMonitor);
+                    networkMonitor, volumeNormalizationService);
             });
 
             services.AddSingleton<IDeviceProfileService, DeviceProfileService>();
@@ -591,8 +594,9 @@ namespace Gelatinarm
                 var queueService = provider.GetRequiredService<IPlaybackQueueService>();
                 var mediaControlService = provider.GetRequiredService<IMediaControlService>();
                 var apiClient = provider.GetRequiredService<JellyfinApiClient>();
+                var volumeNormalizationService = provider.GetRequiredService<IVolumeNormalizationService>();
                 return new MusicPlayerService(logger, provider, apiClient, authService, userProfileService, mediaPlaybackService,
-                    deviceService, preferencesService, mediaOptimizationService, queueService, mediaControlService);
+                    deviceService, preferencesService, mediaOptimizationService, queueService, mediaControlService, volumeNormalizationService);
             });
 
             try

--- a/Gelatinarm.csproj
+++ b/Gelatinarm.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Services\PlaybackSourceResolver.cs" />
     <Compile Include="Services\SubtitleService.cs" />
     <Compile Include="Services\UserDataService.cs" />
+    <Compile Include="Services\VolumeNormalizationService.cs" />
     <!-- ViewModels -->
     <Compile Include="ViewModels\BaseViewModel.cs" />
     <Compile Include="ViewModels\FavoritesViewModel.cs" />

--- a/Models/AppPreferences.cs
+++ b/Models/AppPreferences.cs
@@ -26,6 +26,11 @@ namespace Gelatinarm.Models
         // === Audio & Subtitle Preferences ===
         public int DefaultSubtitleStreamIndex { get; set; } = -1;
 
+        // === Volume Normalization ===
+        public bool EnableVolumeNormalization { get; set; } = true; // Enable LUFS-based volume normalization
+        public bool UseAlbumGain { get; set; } = false; // Use album-level normalization instead of track-level
+        public double LufsTarget { get; set; } = -16.0; // Target LUFS level for normalization (-30 to -10)
+
         // === Network & Streaming ===
         public bool EnableDirectPlay { get; set; } = true; // Allow direct play when format is compatible
         public bool AllowAudioStreamCopy { get; set; } = false; // Default to false to avoid audio compatibility issues

--- a/Services/MediaDiscoveryService.cs
+++ b/Services/MediaDiscoveryService.cs
@@ -16,7 +16,7 @@ namespace Gelatinarm.Services
     {
         private const int MAX_SEARCH_HISTORY = 10;
         private static readonly ItemFields[] DefaultItemFields =
-            { ItemFields.Overview, ItemFields.PrimaryImageAspectRatio };
+            { ItemFields.Overview, ItemFields.PrimaryImageAspectRatio, ItemFields.MediaSources, ItemFields.MediaStreams };
         private static readonly ImageType[] DefaultImageTypes =
             { ImageType.Primary, ImageType.Banner, ImageType.Thumb };
         private readonly JellyfinApiClient _apiClient;

--- a/Services/MediaOptimizationService.cs
+++ b/Services/MediaOptimizationService.cs
@@ -27,6 +27,7 @@ namespace Gelatinarm.Services
         private readonly IMemoryMonitor _memoryMonitor;
         private readonly INetworkMonitor _networkMonitor;
         private readonly IPreferencesService _preferencesService;
+        private readonly IVolumeNormalizationService _volumeNormalizationService;
         private readonly ConcurrentDictionary<string, Task<MediaSource>> _preloadTasks = new();
         private readonly Task _initializationTask;
         private int _currentBandwidthKbps = 0;
@@ -45,13 +46,15 @@ namespace Gelatinarm.Services
             IPreferencesService preferencesService,
             IUnifiedDeviceService deviceService,
             IMemoryMonitor memoryMonitor,
-            INetworkMonitor networkMonitor) : base(logger)
+            INetworkMonitor networkMonitor,
+            IVolumeNormalizationService volumeNormalizationService) : base(logger)
         {
             _httpClientFactory = httpClientFactory;
             _preferencesService = preferencesService;
             _deviceService = deviceService;
             _memoryMonitor = memoryMonitor;
             _networkMonitor = networkMonitor;
+            _volumeNormalizationService = volumeNormalizationService ?? throw new ArgumentNullException(nameof(volumeNormalizationService));
 
             // Start initialization but don't await - will be awaited when needed
             _initializationTask = InitializeAsync();
@@ -315,6 +318,11 @@ namespace Gelatinarm.Services
 
         public async Task ApplyAudioEnhancementsAsync(MediaPlayer player)
         {
+            await ApplyAudioEnhancementsAsync(player, null).ConfigureAwait(false);
+        }
+
+        public async Task ApplyAudioEnhancementsAsync(MediaPlayer player, BaseItemDto item)
+        {
             if (!IsEnhancementEnabled || player == null)
             {
                 return;
@@ -341,7 +349,13 @@ namespace Gelatinarm.Services
                     player.AudioDeviceType = MediaPlayerAudioDeviceType.Multimedia;
                 }
 
-                Logger.LogInformation($"Audio enhancements applied - Night: {_nightModeEnabled}");
+                // Apply volume normalization if item is provided
+                if (item != null)
+                {
+                    await _volumeNormalizationService.ApplyVolumeNormalizationAsync(player, item).ConfigureAwait(false);
+                }
+
+                Logger.LogInformation($"Audio enhancements applied - Night: {_nightModeEnabled}, Item: {item?.Name ?? "None"}");
                 await Task.CompletedTask.ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -351,6 +365,11 @@ namespace Gelatinarm.Services
         }
 
         public async Task ConfigureForXboxAsync(MediaPlayer player, MediaSourceInfo mediaSourceInfo)
+        {
+            await ConfigureForXboxAsync(player, mediaSourceInfo, null).ConfigureAwait(false);
+        }
+
+        public async Task ConfigureForXboxAsync(MediaPlayer player, MediaSourceInfo mediaSourceInfo, BaseItemDto item)
         {
             if (!_deviceService.IsXboxEnvironment || player == null)
             {
@@ -365,7 +384,7 @@ namespace Gelatinarm.Services
 
                 // Apply both video and audio enhancements
                 await ApplyVideoEnhancementsAsync(player, mediaSourceInfo).ConfigureAwait(false);
-                await ApplyAudioEnhancementsAsync(player).ConfigureAwait(false);
+                await ApplyAudioEnhancementsAsync(player, item).ConfigureAwait(false);
 
                 Logger.LogInformation("Xbox-specific optimizations applied");
             }

--- a/Services/MediaPlaybackService.cs
+++ b/Services/MediaPlaybackService.cs
@@ -182,6 +182,7 @@ namespace Gelatinarm.Services
                     async () => await _apiClient.Items[itemGuid].GetAsync(config =>
                     {
                         config.QueryParameters.UserId = userGuid;
+                        // Note: Individual item endpoint returns all fields by default, Fields parameter not supported
                     }, cancellationToken).ConfigureAwait(false),
                     cancellationToken: cancellationToken
                 ).ConfigureAwait(false);

--- a/Services/MusicPlayerService.cs
+++ b/Services/MusicPlayerService.cs
@@ -31,6 +31,7 @@ namespace Gelatinarm.Services
         private readonly IPlaybackQueueService _queueService;
         private readonly IServiceProvider _serviceProvider;
         private readonly IUserProfileService _userProfileService;
+        private readonly IVolumeNormalizationService _volumeNormalizationService;
         private MediaSourceInfo _currentMediaSource;
         private string _currentPlaySessionId;
         private bool _isInFallbackMode = false;
@@ -55,7 +56,8 @@ namespace Gelatinarm.Services
             IPreferencesService preferencesService,
             IMediaOptimizationService mediaOptimizationService,
             IPlaybackQueueService queueService,
-            IMediaControlService mediaControlService) : base(logger)
+            IMediaControlService mediaControlService,
+            IVolumeNormalizationService volumeNormalizationService) : base(logger)
         {
             _serviceProvider = serviceProvider;
             _apiClient = apiClient;
@@ -67,6 +69,7 @@ namespace Gelatinarm.Services
             _mediaOptimizationService = mediaOptimizationService;
             _queueService = queueService;
             _mediaControlService = mediaControlService;
+            _volumeNormalizationService = volumeNormalizationService ?? throw new ArgumentNullException(nameof(volumeNormalizationService));
 
             // Don't subscribe to events in constructor - wait until audio playback starts
             // Initialize();
@@ -1479,6 +1482,29 @@ namespace Gelatinarm.Services
                     Logger.LogInformation("Setting new MediaPlaybackItem as source");
                     _lastPlaybackStartTime = DateTime.UtcNow;
                     await _mediaControlService.SetMediaSource(playbackItem, item).ConfigureAwait(false);
+
+                    // Apply volume normalization for audio items
+                    if (item.Type == BaseItemDto_Type.Audio)
+                    {
+                        var normalizationItem = item;
+                        try
+                        {
+                            var fullItem = await _mediaPlaybackService.GetItemAsync(item.Id?.ToString(), CancellationToken.None).ConfigureAwait(false);
+                            if (fullItem != null)
+                            {
+                                normalizationItem = fullItem;
+                                Logger.LogInformation("Loaded full item metadata for volume normalization");
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogWarning(ex, "Failed to refresh item metadata for normalization, using original item");
+                        }
+
+                        await _volumeNormalizationService.ApplyVolumeNormalizationAsync(
+                            _mediaControlService.MediaPlayer, normalizationItem).ConfigureAwait(false);
+                    }
+
                     _mediaControlService.Play();
 
                     Logger.LogInformation("Successfully set media source and started playback");

--- a/Services/ServiceInterfaces.cs
+++ b/Services/ServiceInterfaces.cs
@@ -416,7 +416,9 @@ namespace Gelatinarm.Services
         bool IsOptimizationEnabled { get; }
         Task ApplyVideoEnhancementsAsync(MediaPlayer player, MediaSourceInfo mediaSourceInfo);
         Task ApplyAudioEnhancementsAsync(MediaPlayer player);
+        Task ApplyAudioEnhancementsAsync(MediaPlayer player, BaseItemDto item);
         Task ConfigureForXboxAsync(MediaPlayer player, MediaSourceInfo mediaSourceInfo);
+        Task ConfigureForXboxAsync(MediaPlayer player, MediaSourceInfo mediaSourceInfo, BaseItemDto item);
         Task ResetEnhancementsAsync(MediaPlayer player);
 
         // Audio Enhancement Settings
@@ -457,6 +459,27 @@ namespace Gelatinarm.Services
             string accessToken,
             bool isAudio,
             IPreferencesService preferences = null);
+    }
+
+    /// <summary>
+    /// Service for handling volume normalization using LUFS data from Jellyfin
+    /// </summary>
+    public interface IVolumeNormalizationService
+    {
+        /// <summary>
+        /// Applies volume normalization to a MediaPlayer based on the item's LUFS data
+        /// </summary>
+        Task ApplyVolumeNormalizationAsync(MediaPlayer player, BaseItemDto item, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets the current volume multiplier for an item without applying it
+        /// </summary>
+        Task<double?> GetVolumeMultiplierAsync(BaseItemDto item, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clears the LUFS cache
+        /// </summary>
+        void ClearCache();
     }
 
     // Supporting classes

--- a/Services/VolumeNormalizationService.cs
+++ b/Services/VolumeNormalizationService.cs
@@ -1,0 +1,329 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Gelatinarm.Constants;
+using Gelatinarm.Helpers;
+using Gelatinarm.Models;
+using Jellyfin.Sdk.Generated.Models;
+using Microsoft.Extensions.Logging;
+using Windows.Media.Playback;
+
+namespace Gelatinarm.Services
+{
+    /// <summary>
+    /// Service for handling volume normalization using LUFS data from Jellyfin
+    /// </summary>
+    public class VolumeNormalizationService : BaseService, IVolumeNormalizationService
+    {
+        private readonly IPreferencesService _preferencesService;
+        private readonly ConcurrentDictionary<string, LufsData> _lufsCache = new();
+        private const double MIN_VOLUME_MULTIPLIER = 0.1; // Minimum volume (10% of reference)
+        private const double MAX_VOLUME_MULTIPLIER = 2.0; // Maximum volume (200% of reference)
+
+        public VolumeNormalizationService(
+            ILogger<VolumeNormalizationService> logger,
+            IPreferencesService preferencesService) : base(logger)
+        {
+            _preferencesService = preferencesService ?? throw new ArgumentNullException(nameof(preferencesService));
+        }
+
+        /// <summary>
+        /// Applies volume normalization to a MediaPlayer based on the item's LUFS data
+        /// </summary>
+        public async Task ApplyVolumeNormalizationAsync(MediaPlayer player, BaseItemDto item, CancellationToken cancellationToken = default)
+        {
+            if (player == null || item == null)
+            {
+                return;
+            }
+
+            var context = CreateErrorContext("ApplyVolumeNormalization", ErrorCategory.Media);
+            try
+            {
+                var prefs = await _preferencesService.GetAppPreferencesAsync().ConfigureAwait(false);
+
+                Logger.LogDebug(
+                    "Volume normalization prefs: Enabled={Enable}, UseAlbumGain={UseAlbum}, LufsTarget={Target}",
+                    prefs.EnableVolumeNormalization, prefs.UseAlbumGain, prefs.LufsTarget);
+
+                if (!prefs.EnableVolumeNormalization)
+                {
+                    Logger.LogDebug("Volume normalization is disabled");
+                    return;
+                }
+
+                var normalizationGain = await GetNormalizationGainAsync(item, prefs.UseAlbumGain, prefs.LufsTarget, cancellationToken).ConfigureAwait(false);
+
+                if (!normalizationGain.HasValue)
+                {
+                    Logger.LogDebug("No normalization gain/LUFS data available for item {ItemId}", item.Id);
+                    return;
+                }
+
+                var volumeMultiplier = CalculateVolumeMultiplier(normalizationGain.Value);
+                const double referenceVolume = 1.0;
+                var finalVolume = Math.Clamp(volumeMultiplier * referenceVolume, 0.0, 1.0);
+
+                await UIHelper.RunOnUIThreadAsync(() =>
+                {
+                    player.Volume = finalVolume;
+                }).ConfigureAwait(false);
+
+                Logger.LogInformation(
+                    "Applied volume normalization: Item={ItemId}, RawGain={RawGain:F3}, Target={Target:F1}, Multiplier={Multiplier:F3}, FinalVolume={FinalVolume:F3}",
+                    item.Id, normalizationGain.Value, prefs.LufsTarget, volumeMultiplier, finalVolume);
+            }
+            catch (Exception ex)
+            {
+                await ErrorHandler.HandleErrorAsync(ex, context, false);
+            }
+        }
+
+        /// <summary>
+        /// Gets the normalization gain multiplier for an item, preferring album gain if enabled
+        /// </summary>
+        private async Task<double?> GetNormalizationGainAsync(BaseItemDto item, bool useAlbumGain, double targetLufs, CancellationToken cancellationToken)
+        {
+            if (item == null)
+            {
+                return null;
+            }
+
+            var cacheKey = $"{item.Id}_{(useAlbumGain ? "album" : "track")}";
+
+            // Check cache first
+            if (_lufsCache.TryGetValue(cacheKey, out var cachedData) &&
+                (DateTime.UtcNow - cachedData.Timestamp) < TimeSpan.FromHours(1))
+            {
+                return cachedData.LufsValue;
+            }
+
+            double? gainValue = null;
+
+            try
+            {
+                var itemType = item.GetType();
+                Logger.LogDebug("Getting normalization gain for item {ItemId} at type {Type}", item.Id, itemType.FullName);
+
+                if (useAlbumGain)
+                {
+                    var albumGainProperty = itemType.GetProperty("AlbumNormalizationGain");
+                    if (albumGainProperty != null)
+                    {
+                        var albumGain = GetNumericValue(albumGainProperty.GetValue(item));
+                        if (albumGain.HasValue)
+                        {
+                            gainValue = CalculateLinearGainFromDb(albumGain.Value);
+                            Logger.LogDebug("Using album normalization gain (dB={Db:F2}) => multiplier {Gain:F3}", albumGain.Value, gainValue.Value);
+                        }
+                        else
+                        {
+                            Logger.LogDebug("AlbumNormalizationGain property exists but has no value for item {ItemId}", item.Id);
+                        }
+                    }
+                    else
+                    {
+                        Logger.LogDebug("AlbumNormalizationGain property not found for item {ItemId}", item.Id);
+                    }
+                }
+
+                if (!gainValue.HasValue)
+                {
+                    var trackGainProperty = itemType.GetProperty("NormalizationGain");
+                    if (trackGainProperty != null)
+                    {
+                        var trackGain = GetNumericValue(trackGainProperty.GetValue(item));
+                        if (trackGain.HasValue)
+                        {
+                            gainValue = CalculateLinearGainFromDb(trackGain.Value);
+                            Logger.LogDebug("Using track normalization gain (dB={Db:F2}) => multiplier {Gain:F3}", trackGain.Value, gainValue.Value);
+                        }
+                    }
+                    else
+                    {
+                        Logger.LogDebug("NormalizationGain property not found for item {ItemId}", item.Id);
+                    }
+                }
+
+                if (!gainValue.HasValue)
+                {
+                    var lufsProperty = itemType.GetProperty("Lufs");
+                    if (lufsProperty != null)
+                    {
+                        var lufsRawValue = GetNumericValue(lufsProperty.GetValue(item));
+                        if (lufsRawValue.HasValue)
+                        {
+                            gainValue = CalculateGainFromLufs(lufsRawValue.Value, targetLufs);
+                            Logger.LogDebug("Calculated gain from LUFS {Lufs:F2} to target {Target:F1}: {Gain:F3}", lufsRawValue.Value, targetLufs, gainValue.Value);
+                        }
+                    }
+                    else
+                    {
+                        Logger.LogDebug("Lufs property not found for item {ItemId}", item.Id);
+                    }
+                }
+
+                // Check MediaStreams for normalization data if not found on the item directly
+                if (!gainValue.HasValue && item.MediaStreams != null)
+                {
+                    Logger.LogDebug("Checking MediaStreams for normalization data, found {Count} streams", item.MediaStreams.Count);
+                    foreach (var stream in item.MediaStreams.Where(s => s.Type == Jellyfin.Sdk.Generated.Models.MediaStream_Type.Audio))
+                    {
+                        Logger.LogDebug("Checking audio stream {Index} for normalization properties", stream.Index);
+
+                        // Check for normalization properties on the stream
+                        var streamType = stream.GetType();
+                        var streamNormalizationGain = GetNumericValue(streamType.GetProperty("NormalizationGain")?.GetValue(stream));
+                        var streamAlbumGain = GetNumericValue(streamType.GetProperty("AlbumNormalizationGain")?.GetValue(stream));
+                        var streamLufs = GetNumericValue(streamType.GetProperty("Lufs")?.GetValue(stream));
+
+                        if (useAlbumGain && streamAlbumGain.HasValue)
+                        {
+                            gainValue = CalculateLinearGainFromDb(streamAlbumGain.Value);
+                            Logger.LogDebug("Found album normalization gain in MediaStream {Index}: {Db:F2} dB => multiplier {Gain:F3}", stream.Index, streamAlbumGain.Value, gainValue.Value);
+                            break;
+                        }
+                        else if (!useAlbumGain && streamNormalizationGain.HasValue)
+                        {
+                            gainValue = CalculateLinearGainFromDb(streamNormalizationGain.Value);
+                            Logger.LogDebug("Found track normalization gain in MediaStream {Index}: {Db:F2} dB => multiplier {Gain:F3}", stream.Index, streamNormalizationGain.Value, gainValue.Value);
+                            break;
+                        }
+                        else if (streamLufs.HasValue)
+                        {
+                            gainValue = CalculateGainFromLufs(streamLufs.Value, targetLufs);
+                            Logger.LogDebug("Found LUFS in MediaStream {Index}: {Lufs:F2} => multiplier {Gain:F3}", stream.Index, streamLufs.Value, gainValue.Value);
+                            break;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Error accessing normalization properties from BaseItemDto or MediaStreams");
+            }
+
+            if (gainValue.HasValue)
+            {
+                _lufsCache[cacheKey] = new LufsData
+                {
+                    LufsValue = gainValue.Value,
+                    Timestamp = DateTime.UtcNow
+                };
+            }
+
+            return gainValue;
+        }
+
+        /// <summary>
+        /// Calculates volume gain from LUFS value to target LUFS level
+        /// </summary>
+        private double CalculateGainFromLufs(double lufs, double targetLufs)
+        {
+            // Convert LUFS to linear gain: gain = 10^(LUFS_diff/20)
+            // Positive LUFS means quieter than reference, so we boost volume
+            // Negative LUFS means louder than reference, so we reduce volume
+            var lufsDiff = targetLufs - lufs;
+            return Math.Pow(10, lufsDiff / 20.0);
+        }
+
+        private static double? GetNumericValue(object value)
+        {
+            if (value is null)
+            {
+                return null;
+            }
+
+            if (value is double numericDouble)
+            {
+                return numericDouble;
+            }
+            if (value is float numericFloat)
+            {
+                return numericFloat;
+            }
+            if (value is int numericInt)
+            {
+                return numericInt;
+            }
+            if (value is long numericLong)
+            {
+                return numericLong;
+            }
+            if (value is decimal numericDecimal)
+            {
+                return (double)numericDecimal;
+            }
+            if (value is double && value != null)
+            {
+                return (double)value;
+            }
+            if (value is float && value != null)
+            {
+                return (float)value;
+            }
+            if (value is int && value != null)
+            {
+                return (int)value;
+            }
+            if (value is long && value != null)
+            {
+                return (long)value;
+            }
+            if (value is decimal && value != null)
+            {
+                return (double)(decimal)value;
+            }
+
+            return null;
+        }
+
+        private double CalculateLinearGainFromDb(double dbGain)
+        {
+            // Convert a dB gain value to a linear multiplier
+            return Math.Pow(10, dbGain / 20.0);
+        }
+
+        /// <summary>
+        /// Calculates the final volume multiplier from gain value
+        /// </summary>
+        private double CalculateVolumeMultiplier(double gain)
+        {
+            // The gain value is a linear multiplier and is clamped to avoid extreme volume changes.
+            return Math.Clamp(gain, MIN_VOLUME_MULTIPLIER, MAX_VOLUME_MULTIPLIER);
+        }
+
+        /// <summary>
+        /// Clears the LUFS cache
+        /// </summary>
+        public void ClearCache()
+        {
+            _lufsCache.Clear();
+            Logger.LogInformation("LUFS cache cleared");
+        }
+
+        /// <summary>
+        /// Gets the current volume multiplier for an item without applying it
+        /// </summary>
+        public async Task<double?> GetVolumeMultiplierAsync(BaseItemDto item, CancellationToken cancellationToken = default)
+        {
+            var prefs = await _preferencesService.GetAppPreferencesAsync().ConfigureAwait(false);
+
+            if (!prefs.EnableVolumeNormalization)
+            {
+                return null;
+            }
+
+            var gainValue = await GetNormalizationGainAsync(item, prefs.UseAlbumGain, prefs.LufsTarget, cancellationToken).ConfigureAwait(false);
+            return gainValue.HasValue ? CalculateVolumeMultiplier(gainValue.Value) : (double?)null;
+        }
+
+        private class LufsData
+        {
+            public double LufsValue { get; set; }
+            public DateTime Timestamp { get; set; }
+        }
+    }
+}

--- a/ViewModels/PlaybackSettingsViewModel.cs
+++ b/ViewModels/PlaybackSettingsViewModel.cs
@@ -44,6 +44,9 @@ namespace Gelatinarm.ViewModels
         private string _videoStretchMode = "Uniform";
         // Audio enhancement settings
         private bool _isNightModeEnabled = false;
+        private bool _enableVolumeNormalization = true;
+        private bool _useAlbumGain = false;
+        private double _lufsTarget = -16.0;
 
         public PlaybackSettingsViewModel(
             ILogger<PlaybackSettingsViewModel> logger,
@@ -208,9 +211,11 @@ namespace Gelatinarm.ViewModels
                 _allowAudioStreamCopy = appPrefs.AllowAudioStreamCopy;
                 _videoStretchMode = appPrefs.VideoStretchMode;
 
-                // Audio enhancement settings - these may not exist in AppPreferences yet
-                // so we'll use default values for now
-                _isNightModeEnabled = false;  // Default to false
+                // Audio enhancement settings - night mode is stored separately in MediaOptimizationService
+                _isNightModeEnabled = _mediaOptimizationService.GetNightModePreference();
+                _enableVolumeNormalization = appPrefs.EnableVolumeNormalization;
+                _useAlbumGain = appPrefs.UseAlbumGain;
+                _lufsTarget = appPrefs.LufsTarget;
 
                 // Notify all properties changed
                 OnPropertyChanged(nameof(AutoPlayNextEpisode));
@@ -221,6 +226,9 @@ namespace Gelatinarm.ViewModels
                 OnPropertyChanged(nameof(AllowAudioStreamCopy));
                 OnPropertyChanged(nameof(VideoStretchMode));
                 OnPropertyChanged(nameof(IsNightModeEnabled));
+                OnPropertyChanged(nameof(EnableVolumeNormalization));
+                OnPropertyChanged(nameof(UseAlbumGain));
+                OnPropertyChanged(nameof(LufsTarget));
             });
         }
 
@@ -248,6 +256,9 @@ namespace Gelatinarm.ViewModels
             AllowAudioStreamCopy = false;
             VideoStretchMode = "Uniform";
             IsNightModeEnabled = false;
+            EnableVolumeNormalization = true;
+            UseAlbumGain = false;
+            LufsTarget = -16.0;
 
             await Task.CompletedTask;
         }
@@ -427,6 +438,48 @@ namespace Gelatinarm.ViewModels
 
                     // Call MediaOptimizationService if it has night mode methods
                     _mediaOptimizationService?.SetNightMode(value);
+                }
+            }
+        }
+
+        public bool EnableVolumeNormalization
+        {
+            get => _enableVolumeNormalization;
+            set
+            {
+                if (SetSettingProperty(ref _enableVolumeNormalization, value))
+                {
+                    FireAndForget(
+                        () => UpdateAppPreferenceAsync(prefs => prefs.EnableVolumeNormalization = value,
+                            nameof(EnableVolumeNormalization)));
+                }
+            }
+        }
+
+        public bool UseAlbumGain
+        {
+            get => _useAlbumGain;
+            set
+            {
+                if (SetSettingProperty(ref _useAlbumGain, value))
+                {
+                    FireAndForget(
+                        () => UpdateAppPreferenceAsync(prefs => prefs.UseAlbumGain = value,
+                            nameof(UseAlbumGain)));
+                }
+            }
+        }
+
+        public double LufsTarget
+        {
+            get => _lufsTarget;
+            set
+            {
+                if (SetSettingProperty(ref _lufsTarget, Math.Clamp(value, -30.0, -10.0)))
+                {
+                    FireAndForget(
+                        () => UpdateAppPreferenceAsync(prefs => prefs.LufsTarget = _lufsTarget,
+                            nameof(LufsTarget)));
                 }
             }
         }

--- a/Views/SettingsPage.xaml
+++ b/Views/SettingsPage.xaml
@@ -197,6 +197,54 @@
                         TextWrapping="Wrap"
                         FontSize="12" />
 
+                    <ToggleSwitch Header="Volume Normalization"
+                                  IsOn="{x:Bind TypedViewModel.PlaybackSettings.EnableVolumeNormalization, Mode=TwoWay}"
+                                  Style="{StaticResource StandardToggleSwitchStyle}"
+                                  OnContent="Normalize volume using LUFS data"
+                                  OffContent="Play at original volume levels" />
+                    <TextBlock
+                        Text="Automatically adjusts volume levels to compensate for differences between tracks. Uses Loudness Units Full Scale (LUFS) data calculated by the Jellyfin server."
+                        Style="{StaticResource BodyTextBlockStyle}"
+                        Opacity="0.7"
+                        Margin="0,0,0,12"
+                        TextWrapping="Wrap"
+                        FontSize="12" />
+
+                    <ToggleSwitch Header="Album Gain Mode"
+                                  IsOn="{x:Bind TypedViewModel.PlaybackSettings.UseAlbumGain, Mode=TwoWay}"
+                                  Style="{StaticResource StandardToggleSwitchStyle}"
+                                  OnContent="Use album-level normalization"
+                                  OffContent="Use track-level normalization" />
+                    <TextBlock
+                        Text="When enabled, uses the same volume adjustment for all tracks in an album. When disabled, adjusts each track individually. Requires Volume Normalization to be enabled."
+                        Style="{StaticResource BodyTextBlockStyle}"
+                        Opacity="0.7"
+                        Margin="0,0,0,12"
+                        TextWrapping="Wrap"
+                        FontSize="12" />
+
+                    <StackPanel>
+                        <TextBlock>
+                            <Run Text="LUFS Target Level: " />
+                            <Run Text="{x:Bind TypedViewModel.PlaybackSettings.LufsTarget, Mode=OneWay}" />
+                            <Run Text=" LUFS" />
+                        </TextBlock>
+                        <Slider Minimum="-30"
+                                Maximum="-10"
+                                Value="{x:Bind TypedViewModel.PlaybackSettings.LufsTarget, Mode=TwoWay}"
+                                StepFrequency="0.5"
+                                TickFrequency="2"
+                                SnapsTo="StepValues"
+                                Style="{StaticResource StandardSliderStyle}" />
+                    </StackPanel>
+                    <TextBlock
+                        Text="Adjusts the target loudness level for volume normalization. Lower values (-23 to -30) provide quieter, more consistent playback. Higher values (-16 to -10) allow louder playback but with more variation between tracks."
+                        Style="{StaticResource BodyTextBlockStyle}"
+                        Opacity="0.7"
+                        Margin="0,0,0,12"
+                        TextWrapping="Wrap"
+                        FontSize="12" />
+
 
                 </StackPanel>
             </StackPanel>


### PR DESCRIPTION
**Overview**
This pull request introduces a comprehensive volume normalization feature to Gelatinarm, allowing users to automatically adjust playback volume levels to compensate for differences between tracks using Loudness Units Full Scale (LUFS) data provided by the Jellyfin server.

**Key Features**
- LUFS-based Volume Normalization: Automatically adjusts volume levels using LUFS data calculated by Jellyfin server
- Album vs Track Gain Modes: Option to use album-level normalization (consistent volume across an album) or track-level normalization (individual adjustment per track.
- Configurable Target Level: Adjustable LUFS target level from -30 to -10 LUFS with a default of -16 LUFS
- Smart Fallback Logic: Falls back through multiple data sources (album gain, track gain, LUFS values) for maximum compatibility
- Caching System: Efficient caching of normalization data with 1-hour expiration
- Safety Limits: Volume multipliers clamped between 10% and 200% to prevent extreme volume changes

**Big Fix**
- The night mode toggle in the settings page correctly reflects the current state
- Users can properly enable/disable night mode through the UI
- The night mode setting persists between app sessions

**Technical Implementation**
- New Service: VolumeNormalizationService
- Implements IVolumeNormalizationService interface
- Handles LUFS data extraction from Jellyfin BaseItemDto objects and MediaStreams
- Calculates linear gain multipliers from dB values and LUFS measurements
- Provides async methods for applying normalization to MediaPlayer instances

**Core Changes**
- Dependency Injection: Registered VolumeNormalizationService in the DI container
- MediaOptimizationService: Enhanced audio enhancement methods to accept item context for normalization
- MusicPlayerService: Integrated volume normalization during audio playback initialization
- Settings Infrastructure: Added volume normalization preferences to AppPreferences model
- UI Components: Added toggle switches and slider controls in SettingsPage for user configuration

**Data Source Priority**
- Album normalization gain (when album mode enabled)
- Track normalization gain
- LUFS values from item properties
- Normalization data from MediaStreams

**User Experience**
- Settings Page: New controls under Audio Enhancements section
- Automatic Application: Normalization applies seamlessly during audio playback
- Visual Feedback: Settings show current values and provide helpful descriptions
- Performance: Minimal impact with efficient caching and async operations

**Compatibility**
- Works with Jellyfin servers that provide LUFS/normalization data
- Graceful degradation when data is unavailable
- Backward compatible with existing audio playback

**Import Testing Considerations** 
Testing was completed successfully on Windows 11, I am currently not able to test via Xbox hardware. Please consider testing on Xbox before approving this merge. 
Changes were primary made by Claude and testing may not have accounted for every use case. 

@gitman-101111 

